### PR TITLE
MySQL 8.0.2 より「rank」が予約語になったので、バッククオートを追加

### DIFF
--- a/EccubeCreateOrderSql.php
+++ b/EccubeCreateOrderSql.php
@@ -382,7 +382,7 @@ class EccubeCreateOrderSql
                     .'fee_id, shipping_name01, shipping_name02, shipping_kana01, shipping_kana02, shipping_company_name,'
                     .'shipping_tel01, shipping_tel02, shipping_tel03, shipping_fax01, shipping_fax02, shipping_fax03, shipping_zip01, shipping_zip02,'
                     .'shipping_zipcode, shipping_addr01, shipping_addr02, shipping_delivery_name, shipping_delivery_time, shipping_delivery_date, shipping_delivery_fee, shipping_commit_date,'
-                    .'rank, create_date, update_date, del_flg) VALUES '.PHP_EOL;
+                    .'`rank`, create_date, update_date, del_flg) VALUES '.PHP_EOL;
                 $importShippingSql .= implode(','.PHP_EOL, $shippingValues).";";
 
                 $file->fwrite(PHP_EOL);

--- a/EccubeCreateProductSql.php
+++ b/EccubeCreateProductSql.php
@@ -21,7 +21,7 @@ class EccubeCreateProductSql
      */
     public function writeCategorySql()
     {
-        $sql = 'SELECT * FROM dtb_category ORDER BY level, category_id, parent_category_id, rank;';
+        $sql = 'SELECT * FROM dtb_category ORDER BY level, category_id, parent_category_id, `rank`;';
 
         $rows = Common::fetch($this->conn, $sql);
 
@@ -32,7 +32,7 @@ class EccubeCreateProductSql
         $lastItem = end($rows);
 
         // insert文
-        $sql = 'INSERT INTO dtb_category (category_id, category_name, parent_category_id, level, rank, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
+        $sql = 'INSERT INTO dtb_category (category_id, category_name, parent_category_id, level, `rank`, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
         $this->file->fwrite($sql);
 
         foreach ($rows as $item) {
@@ -67,7 +67,7 @@ class EccubeCreateProductSql
      */
     public function writeProductCategorySql()
     {
-        $sql = 'SELECT * FROM dtb_product_categories pc INNER JOIN dtb_products p ON pc.product_id = p.product_id INNER JOIN dtb_category c ON pc.category_id = c.category_id ORDER BY pc.product_id, pc.rank;';
+        $sql = 'SELECT * FROM dtb_product_categories pc INNER JOIN dtb_products p ON pc.product_id = p.product_id INNER JOIN dtb_category c ON pc.category_id = c.category_id ORDER BY pc.product_id, pc.`rank`;';
 
         $rows = Common::fetch($this->conn, $sql);
 
@@ -78,7 +78,7 @@ class EccubeCreateProductSql
         $lastItem = end($rows);
 
         // insert文
-        $sql = 'INSERT INTO dtb_product_category (product_id, category_id, rank) VALUES'.PHP_EOL;
+        $sql = 'INSERT INTO dtb_product_category (product_id, category_id, `rank`) VALUES'.PHP_EOL;
         $this->file->fwrite($sql);
 
         foreach ($rows as $item) {
@@ -116,7 +116,7 @@ class EccubeCreateProductSql
         $lastItem = end($rows);
 
         // insert文
-        $sql = 'INSERT INTO dtb_class_name (class_name_id, name, rank, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
+        $sql = 'INSERT INTO dtb_class_name (class_name_id, name, `rank`, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
         $this->file->fwrite(PHP_EOL);
         $this->file->fwrite($sql);
 
@@ -160,7 +160,7 @@ class EccubeCreateProductSql
         $lastItem = end($rows);
 
         // insert文
-        $sql = 'INSERT INTO dtb_class_category (class_category_id, name, class_name_id, rank, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
+        $sql = 'INSERT INTO dtb_class_category (class_category_id, name, class_name_id, `rank`, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
         $this->file->fwrite(PHP_EOL);
         $this->file->fwrite($sql);
 
@@ -205,7 +205,7 @@ class EccubeCreateProductSql
         $lastItem = end($rows);
 
         // insert文
-        $sql = 'INSERT INTO dtb_maker (maker_id, name,rank, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
+        $sql = 'INSERT INTO dtb_maker (maker_id, name, `rank`, creator_id, create_date, update_date, del_flg) VALUES'.PHP_EOL;
         $this->file->fwrite($sql);
 
         foreach ($rows as $item) {
@@ -330,7 +330,7 @@ class EccubeCreateProductSql
 
 
         if (!empty($imageValues)) {
-            $importImageSql = 'INSERT INTO dtb_product_image (product_image_id, product_id, creator_id, file_name, rank, create_date) VALUES'.PHP_EOL;
+            $importImageSql = 'INSERT INTO dtb_product_image (product_image_id, product_id, creator_id, file_name, `rank`, create_date) VALUES'.PHP_EOL;
             $importImageSql .= implode(','.PHP_EOL, $imageValues).";";
             $this->file->fwrite(PHP_EOL);
             $this->file->fwrite($importImageSql);


### PR DESCRIPTION
MySQL 8.0.19 (on PHP 7.4.6) にて

>An error occurred in sql: SELECT * FROM dtb_category ORDER BY level, category_id, parent_category_id, rank;
 
で処理がコケていることに気付きました。。
まずは「rank」にバッククオートを追加したものをプルリクしてみます。